### PR TITLE
Improve action bar on posts

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -74,6 +74,43 @@
 
 
 
+/* Action Buttons on Posts */
+
+nav.post-controls .actions .extra-buttons button,
+nav.post-controls .actions > button {
+	border-radius: var(--theme-radius);
+}
+nav.post-controls .actions .double-button button:first-child {
+	border-top-left-radius: var(--theme-radius);
+	border-bottom-left-radius: var(--theme-radius);
+}
+nav.post-controls .actions .double-button button:last-child {
+	border-top-right-radius: var(--theme-radius);
+	border-bottom-right-radius: var(--theme-radius);
+}
+
+nav.post-controls .actions .unaccepted .d-icon,
+nav.post-controls .actions .double-button button.like .d-icon,
+nav.post-controls .actions .double-button button.toggle-like .d-icon {
+	color: var(--success-medium) !important;
+}
+
+nav.post-controls .actions .unaccepted.d-hover .d-icon,
+nav.post-controls .actions .double-button:hover button.like .d-icon,
+nav.post-controls .actions .double-button:hover button.regular-likes,
+nav.post-controls .actions .double-button:hover button.toggle-like .d-icon {
+	color: var(--secondary) !important;
+}
+
+nav.post-controls .actions .unaccepted.d-hover,
+nav.post-controls .actions .double-button:hover button.like,
+nav.post-controls .actions .double-button:hover button.regular-likes,
+nav.post-controls .actions .double-button:hover button.toggle-like {
+	background-color: var(--success-medium) !important;
+}
+
+
+
 /* Search Banner */
 
 .search-banner {


### PR DESCRIPTION
This introduces the following changes:
- background on hover is rounded
- mark as solved and like buttons use green font
- background on solved and like buttons is green on hover

#### Default View
![image](https://github.com/godotengine/discourse-theme/assets/44872771/1694b00f-b5b6-4957-98ea-19724d2cb85b)

#### Hovered Buttons
![image](https://github.com/godotengine/discourse-theme/assets/44872771/738baba5-f7b7-4d9a-8a64-b2f0540344c2)
![image](https://github.com/godotengine/discourse-theme/assets/44872771/8332dedb-b679-47c0-a825-7cc1eb00b7b1)
![image](https://github.com/godotengine/discourse-theme/assets/44872771/ff2ebf04-97f1-429f-8107-94e6750fe45c)

#### With Like Count
![image](https://github.com/godotengine/discourse-theme/assets/44872771/61b26e83-461e-4b76-a6a8-0c403c5f9d61)
![image](https://github.com/godotengine/discourse-theme/assets/44872771/2b2169b5-c42a-4d88-ac35-2265f15bba00)


Fixes #4 
Fixes #7
