### PR TITLE
Add light mode and always use blue as accent color

### DIFF
--- a/about.json
+++ b/about.json
@@ -4,12 +4,29 @@
   "license_url": "https://github.com/godotengine/discourse-theme/blob/main/LICENSE",
   "about_url": "https://github.com/godotengine/discourse-theme",
   "color_schemes": {
-    "Godot": {
+    "Godot Light": {
+      "primary": "0f1012",
+      "secondary": "f1f1f1",
+      "tertiary": "478cc0",
+      "tertiary-low": "bad9f0",
+      "quaternary": "396f99",
+      "quaternary-low": "739dbd",
+      "highlight-bg": "739dbd",
+      "header_background": "ededed",
+      "header_primary": "333639",
+      "highlight": "f6aa78",
+      "selected": "d4d4d4",
+      "hover": "c9c9c9",
+      "danger": "e45735",
+      "success": "67e6bb",
+      "love": "f57389"
+    },
+    "Godot Dark": {
       "primary": "dddddd",
       "secondary": "202326",
       "tertiary": "85c2e0",
-      "quaternary": "f57389",
-      "quaternary-low": "f573895c",
+      "quaternary": "478cc0",
+      "quaternary-low": "1a364d",
       "highlight-bg": "10456c",
       "header_background": "333639",
       "header_primary": "eeeeee",

--- a/common/common.scss
+++ b/common/common.scss
@@ -14,7 +14,7 @@
 
 .category-boxes .category-box-inner {
 	// Change to a colored and rounded box without a border
-	background-color: var(--header_background);
+	background-color: var(--primary-200);
 	border-radius: var(--theme-radius);
 	border-color: var(--secondary-high);
 	border-width: 0px;


### PR DESCRIPTION
Fixes #9
Fixes #5

Changes:
- introduces light mode
- changes dark mode to use blue for navigation badges

<details>

<summary>Screenshots from first draft (find the final screenshots in the comments further below)</summary>

ToDo:
- [x] Change header image so that it fits to light mode
- [x] Change navbar logo to have dark text

This is still a work in progress. A few screenshots of what I have so far:

![image](https://github.com/godotengine/discourse-theme/assets/44872771/ea243dcf-0432-4ddb-8895-d2e80affa906)

![image](https://github.com/godotengine/discourse-theme/assets/44872771/840d85d4-2416-478f-b1e6-408d8b9a0b3c)

![image](https://github.com/godotengine/discourse-theme/assets/44872771/00f27ad1-fb9c-4b38-a82f-ddfe32277a12)

</details>

